### PR TITLE
Expand usage of LOG macro

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -31,12 +31,12 @@ bool test(std::vector<std::string> input, std::vector<std::string> RPN, std::vec
       double u = parser.eval(input[x]);
 
       if (parser.getRPN().RPN == RPN[x]){
-        std::cout << input[x] << " -> " << RPN[x] << " | Success" << std::endl;
+        LOG(input[x] << " -> " << RPN[x] << " | Success");
         rpn_score++;
       }
 
       else{
-        std::cout << input[x] << " -> " << RPN[x] << " (" << parser.getRPN().RPN << ") | Failed" << std::endl;
+        LOG(input[x] << " -> " << RPN[x] << " (" << parser.getRPN().RPN << ") | Failed");
       }
 
       RPN_Values.push_back(u);
@@ -48,12 +48,12 @@ bool test(std::vector<std::string> input, std::vector<std::string> RPN, std::vec
       double evaluation = RPN_Values[x];
 
       if (evaluation == result[x]){
-        std::cout << input[x] << " -> " << result[x] << " | Success" << std::endl;
+        LOG(input[x] << " -> " << result[x] << " | Success");
         evaluation_score++;
       }
 
       else{
-        std::cout << input[x] << " -> " << result[x] << " (" << evaluation << ") | Failed" << std::endl;
+        LOG(input[x] << " -> " << result[x] << " (" << evaluation << ") | Failed");
       }
     }
 


### PR DESCRIPTION
Macro LOG already existed in test file; just altered so that all `std::cout << x << std::endl` is using it.